### PR TITLE
Disable unit test workflow run for push in main.

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,8 +1,6 @@
 name: Unit tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
As all pushes should pass unittest before being pushed to the main.

Signed-off-by: Kirill Zhosul <79853674+kirillzhosul@users.noreply.github.com>