### PR TITLE
fix(error handlers): Remove trailing space in 'token invalid' error m…

### DIFF
--- a/src/api/app/exception_handlers/_handlers.py
+++ b/src/api/app/exception_handlers/_handlers.py
@@ -82,5 +82,5 @@ async def token_invalid_signature_error_handler(_, __):
 async def token_invalid_error_handler(_, __):
     """Handler for token module token invalid error."""
     return api_error(
-        ApiErrorCode.AUTH_INVALID_TOKEN, "Token invalid! No additonal information. "
+        ApiErrorCode.AUTH_INVALID_TOKEN, "Token invalid! No additonal information."
     )


### PR DESCRIPTION
…essage.

Just fix this terrible trailing space that made me think my gatey client program is not working